### PR TITLE
Add possibility to override email backend

### DIFF
--- a/example-config/opendrift-leeway-webgui.ini
+++ b/example-config/opendrift-leeway-webgui.ini
@@ -39,6 +39,8 @@ EMAIL_PORT = <your-port>
 EMAIL_USE_TLS = True
 # Whether SSL (implicit TLS) is enabled [optional, defaults to False]
 EMAIL_USE_SSL = False
+# The email backend [optional, defaults to "console" in DEBUG mode and "smtp" otherwise]
+EMAIL_BACKEND = smtp
 
 [logging]
 # The path to your log file [optional, defaults to "opendrift-leeway-webgui.log" in the application directory]

--- a/opendrift_leeway_webgui/core/settings.py
+++ b/opendrift_leeway_webgui/core/settings.py
@@ -285,12 +285,12 @@ CELERY_RESULT_BACKEND = "redis://localhost:6379/0"
 # EMAILS #
 ##########
 
-# pylint: disable=consider-ternary-expression
-if DEBUG:
-    #: The backend to use for sending emails (see :setting:`django:EMAIL_BACKEND` and :doc:`django:topics/email`)
-    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-else:
-    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+#: The backend to use for sending emails (see :setting:`django:EMAIL_BACKEND` and :doc:`django:topics/email`)
+EMAIL_BACKEND = (
+    "django.core.mail.backends."
+    + os.environ.get("LEEWAY_EMAIL_BACKEND", "console" if DEBUG else "smtp")
+    + ".EmailBackend"
+)
 
 #: The email address that error messages come from (see :setting:`django:SERVER_EMAIL`)
 SERVER_EMAIL = os.environ.get("LEEWAY_SERVER_EMAIL")


### PR DESCRIPTION
Sometimes, we might want to test real sending of emails also in DEBUG mode.
This enables to override the default email backend by setting e.g. `export LEEWAY_EMAIL_BACKEND=smtp` even when the DEBUG mode is enabled.