### PR TITLE
Fix timezone warning

### DIFF
--- a/opendrift_leeway_webgui/leeway/tasks.py
+++ b/opendrift_leeway_webgui/leeway/tasks.py
@@ -1,9 +1,10 @@
 import os
 import subprocess
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from django.apps import apps
 from django.conf import settings
+from django.utils import timezone
 
 from .celery import app
 from .utils import send_result_mail
@@ -18,7 +19,7 @@ def run_leeway_simulation(request_id):
     # pylint: disable=invalid-name
     LeewaySimulation = apps.get_model(app_label="leeway", model_name="LeewaySimulation")
     simulation = LeewaySimulation.objects.get(uuid=request_id)
-    simulation.simulation_started = datetime.now()
+    simulation.simulation_started = timezone.now()
     simulation.save()
     params = [
         "docker",
@@ -47,7 +48,7 @@ def run_leeway_simulation(request_id):
     ]
     with subprocess.Popen(params) as sim_proc:
         sim_proc.communicate()
-    simulation.simulation_finished = datetime.now()
+    simulation.simulation_finished = timezone.now()
     send_result_mail(simulation)
     simulation.save()
 
@@ -60,7 +61,7 @@ def clean_simulations():
     print("Cleaning old simulation data.")
     for simulation in apps.get_model(
         app_label="leeway", model_name="LeewaySimulation"
-    ).objects.filter(datetime.now() - timedelta(days=settings.SIMULATION_RETENTION)):
+    ).objects.filter(timezone.now() - timedelta(days=settings.SIMULATION_RETENTION)):
         os.remove(os.path.join(settings.SIMULATION_OUTPUT, f"{simulation.uuid}.png"))
         os.remove(os.path.join(settings.SIMULATION_OUTPUT, f"{simulation.uuid}.csv"))
         print(f"Removed simulation {simulation.uuid}.")


### PR DESCRIPTION
Fix the warning:
```
[2022-12-13 18:35:35,495: WARNING/ForkPoolWorker-16] /home/django/django/db/models/fields/__init__.py:1563: RuntimeWarning: DateTimeField LeewaySimulation.simulation_started received a naive datetime (2022-12-13 18:35:01.532693) while time zone support is active.
  warnings.warn(

[2022-12-13 18:35:35,495: WARNING/ForkPoolWorker-16] /home/django/django/db/models/fields/__init__.py:1563: RuntimeWarning: DateTimeField LeewaySimulation.simulation_finished received a naive datetime (2022-12-13 18:35:32.342663) while time zone support is active.
  warnings.warn(
```