### PR TITLE
Run simulations from REST API, fix #50

### DIFF
--- a/opendrift_leeway_webgui/api/v1/serializers.py
+++ b/opendrift_leeway_webgui/api/v1/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from ...leeway.models import LeewaySimulation
+from ...leeway.tasks import run_leeway_simulation
 
 
 class LeewaySimulationSerializer(serializers.ModelSerializer):
@@ -33,3 +34,8 @@ class LeewaySimulationSerializer(serializers.ModelSerializer):
             "simulation_started",
             "simulation_finished",
         ]
+
+    def create(self, validated_data):
+        simulation = LeewaySimulation.objects.create(**validated_data)
+        run_leeway_simulation.apply_async([simulation.uuid])
+        return simulation

--- a/opendrift_leeway_webgui/leeway/utils.py
+++ b/opendrift_leeway_webgui/leeway/utils.py
@@ -154,16 +154,13 @@ def send_result_mail(simulation):
     """
     Create mail parts for result mail
     """
-    # Initialize mail
     email = EmailMessage(
         subject="Leeway Drift Simulation Result",
         body=mail_result_text(simulation),
         to=[simulation.user.email],
     )
-    # Attach result image
     if simulation.img:
         email.attach_file(simulation.img.path)
-    # Send email
     return email.send()
 
 


### PR DESCRIPTION
Simulations that are pushed via REST API are not yet starting automatically. This PR searches for not yet started simulations and creates new jobs.