### PR TITLE
Remove decimals from map axis labels

### DIFF
--- a/opendrift_leeway_webgui/simulation.py
+++ b/opendrift_leeway_webgui/simulation.py
@@ -294,10 +294,10 @@ def main():
     yloc = ticker.FixedLocator(y_ticks)
 
     longitude_formatter = gridliner.LongitudeFormatter(
-        dms=True, auto_hide=False, number_format=".0f"
+        dms=True, auto_hide=False, number_format=".0f", seconds_number_format=".0f"
     )
     latitude_formatter = gridliner.LatitudeFormatter(
-        dms=True, auto_hide=False, number_format=".0f"
+        dms=True, auto_hide=False, number_format=".0f", seconds_number_format=".0f"
     )
 
     gl = ax.gridlines(

--- a/tests/leeway/test_simulation.py
+++ b/tests/leeway/test_simulation.py
@@ -24,7 +24,7 @@ def test_simulation(admin_client, settings, celery_worker, uuid_store):
             "latitude": "33°58'44.3\"",
             "longitude": "11°21'13.4\"",
             "object_type": 27,
-            "start_time": (datetime.now() - timedelta(hours=12)).strftime(
+            "start_time": (datetime.now() - timedelta(hours=36)).strftime(
                 "%Y-%m-%d %H:%M"
             ),
             "duration": 2,


### PR DESCRIPTION
We do not need decimals for arc seconds in our map.